### PR TITLE
Feature/tag delete

### DIFF
--- a/handler/delete_tag.go
+++ b/handler/delete_tag.go
@@ -1,0 +1,38 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-webapi-team/task-app/entity"
+	"github.com/go-webapi-team/task-app/store"
+)
+
+type TagDeleter interface {
+	DeleteTag(ctx context.Context, db store.Execer, userID int64, id entity.TagID) error
+}
+
+type DeleteTag struct {
+	Repo TagDeleter
+	DB   store.Execer
+}
+
+func (dt *DeleteTag) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	idStr := chi.URLParam(r, "id")
+	idInt, err := strconv.ParseInt(idStr, 10, 64) //10進数として解釈し、int64 に収める(DBのPK がBIGINT(64bit) のため)
+	if err != nil {
+		RespondJSON(ctx, w, &ErrResponse{Message: "Invalid tag ID format"}, http.StatusBadRequest)
+		return
+	}
+
+	userID := int64(1) // TODO 認証後に取得
+
+	if err := dt.Repo.DeleteTag(ctx, dt.DB, userID, entity.TagID(idInt)); err != nil {
+		RespondJSON(ctx, w, &ErrResponse{Message: err.Error()}, http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/handler/delete_tag_from_task.go
+++ b/handler/delete_tag_from_task.go
@@ -22,7 +22,7 @@ type DeleteTagFromTask struct {
 
 func (dt *DeleteTagFromTask) ServeHTTP(w http.ResponseWriter, r *http.Request) {
     ctx := r.Context()
-    taskIDStr    := chi.URLParam(r, "task_id")
+    taskIDStr := chi.URLParam(r, "task_id")
     tagIDStr := chi.URLParam(r, "tag_id")
 
     taskInt, err := strconv.ParseInt(taskIDStr, 10, 64)

--- a/handler/delete_tag_test.go
+++ b/handler/delete_tag_test.go
@@ -1,0 +1,36 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-webapi-team/task-app/entity"
+	"github.com/go-webapi-team/task-app/store"
+)
+
+// ダミー TagDeleter
+type fakeTagDeleter struct{}
+
+func (f *fakeTagDeleter) DeleteTag(_ context.Context, _ store.Execer, _ int64, _ entity.TagID) error {
+	return nil
+}
+
+func TestDeleteTag_OK(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodDelete, "/tags/5", nil)
+
+	// chi の URL パラメータを埋め込む
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "5")
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	sut := DeleteTag{Repo: &fakeTagDeleter{}, DB: nil}
+	sut.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", w.Code)
+	}
+}

--- a/mux.go
+++ b/mux.go
@@ -24,14 +24,14 @@ func NewMux(db *sql.DB, repo *store.Repository) http.Handler {
 	mux.Get("/tags", listTag.ServeHTTP)
 
 	deleteTag := &handler.DeleteTag{Repo: repo, DB: db}
-	mux.DELETE("/tags", deleteTag.ServeHTTP)
+	mux.Delete("/tags/{id}", deleteTag.ServeHTTP)
 
 	// Task ハンドラ
 	addTask := &handler.AddTask{Repo: repo, DB: db, Validator: v}
 	mux.Post("/tasks", addTask.ServeHTTP)
 
 	listTask := &handler.ListTask{Repo: repo, DB: db}
-	mux.Get("/tasks", listTag.ServeHTTP)
+	mux.Get("/tasks", listTask.ServeHTTP)
 
 	getTask := &handler.GetTask{Repo: repo, DB: db}
 	mux.Get("/tasks/{id}", getTask.ServeHTTP)

--- a/mux.go
+++ b/mux.go
@@ -16,35 +16,31 @@ func NewMux(db *sql.DB, repo *store.Repository) http.Handler {
 	mux := chi.NewRouter()
 	v := validator.New()
 
-	// RDB 永続化版ハンドラ
-	createTag := &handler.CreateTag{
-		Repo:      repo,
-		DB:        db,
-		Validator: v,
-	}
+	// Tagハンドラ
+	createTag := &handler.CreateTag{Repo: repo, DB: db, Validator: v}
 	mux.Post("/tags", createTag.ServeHTTP)
 
-	lt := &handler.ListTag{
-		Repo: repo,
-		DB:   db,
-	}
-	mux.Get("/tags", lt.ServeHTTP)
+	listTag := &handler.ListTag{Repo: repo, DB: db}
+	mux.Get("/tags", listTag.ServeHTTP)
+
+	deleteTag := &handler.DeleteTag{Repo: repo, DB: db}
+	mux.DELETE("/tags", deleteTag.ServeHTTP)
 
 	// Task ハンドラ
-	at := &handler.AddTask{Repo: repo, DB: db, Validator: v}
-	mux.Post("/tasks", at.ServeHTTP)
+	addTask := &handler.AddTask{Repo: repo, DB: db, Validator: v}
+	mux.Post("/tasks", addTask.ServeHTTP)
 
-	ltask := &handler.ListTask{Repo: repo, DB: db}
-	mux.Get("/tasks", ltask.ServeHTTP)
+	listTask := &handler.ListTask{Repo: repo, DB: db}
+	mux.Get("/tasks", listTag.ServeHTTP)
 
-	gt := &handler.GetTask{Repo: repo, DB: db}
-	mux.Get("/tasks/{id}", gt.ServeHTTP)
+	getTask := &handler.GetTask{Repo: repo, DB: db}
+	mux.Get("/tasks/{id}", getTask.ServeHTTP)
 
-	ut := &handler.UpdateTask{Repo: repo, DB: db, Validator: v}
-	mux.Put("/tasks/{id}", ut.ServeHTTP)
+	updateTask := &handler.UpdateTask{Repo: repo, DB: db, Validator: v}
+	mux.Put("/tasks/{id}", updateTask.ServeHTTP)
 
-	dt := &handler.DeleteTask{Repo: repo, DB: db}
-	mux.Delete("/tasks/{id}", dt.ServeHTTP)
+	deleteTask := &handler.DeleteTask{Repo: repo, DB: db}
+	mux.Delete("/tasks/{id}", deleteTask.ServeHTTP)
 
 	toggleComplete := &handler.ToggleCompleteTask{Repo: repo, DB: db}
 	mux.Patch("/tasks/{id}/complete", toggleComplete.ServeHTTP)

--- a/store/tag.go
+++ b/store/tag.go
@@ -48,6 +48,18 @@ func (r *Repository) ListTags(ctx context.Context, db Queryer) (entity.Tags, err
 	return tags, nil
 }
 
+func (r *Repository) DeleteTag(ctx context.Context, db Execer, userID int64, id entity.TagID) error {
+	res, err := db.ExecContext(ctx, `DELETE FROM tags WHERE id=? AND user_id=?`, id, userID)
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
+	}
+		
+	return nil
+}
+
 func (r *Repository) AddTagToTask(ctx context.Context, db Execer, userID int64, t *entity.TaskTag) error {
 	now := r.Clocker.Now()
 	const q = `

--- a/store/tag.go
+++ b/store/tag.go
@@ -92,7 +92,10 @@ func (r *Repository) DeleteTagFromTask(ctx context.Context, db Execer, userID in
     if err != nil {
         return err
     }
-    n, _ := res.RowsAffected()
+    n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
     if n == 0 {
         return ErrNotFound
     }

--- a/store/tag_test.go
+++ b/store/tag_test.go
@@ -75,3 +75,30 @@ func TestTagRepository_CreateTag(t *testing.T) {
 		t.Errorf("ID not set, got %d want %d", newTag.ID, wantID)
 	}
 }
+
+func TestTagRepository_DeleteTag(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	// 期待: id=5, user_id=1 の行を 1 行削除
+	mock.ExpectExec(`DELETE FROM tags`).
+		WithArgs(int64(5), int64(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	r := &Repository{}
+	if err := r.DeleteTag(ctx, db, 1, entity.TagID(5)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("mock expectations not met: %v", err)
+	}
+}
+


### PR DESCRIPTION
タグ単体の削除のエンドポイントを作成しました
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- New Feature: タグをIDで削除するための新しいHTTPハンドラ`DeleteTag`が追加されました。
- Test: タグ削除エンドポイントのテストが追加され、正常な動作を確認しました。
- Bug fix: `DeleteTagFromTask`関数でのエラーハンドリングが改善されました。
- Style: `DeleteTagFromTask`構造体内の変数インデントが修正されました。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->