### PR TITLE
Feature/handler repo user

### DIFF
--- a/handler/add_tag_to_task.go
+++ b/handler/add_tag_to_task.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-webapi-team/task-app/auth"
 	"github.com/go-webapi-team/task-app/entity"
 	"github.com/go-webapi-team/task-app/store"
 )
@@ -51,8 +52,14 @@ func (at *AddTagToTask) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: 認証実装後に ctx から取得
-    userID := int64(1)
+	// ------------------------------
+	// 認証ユーザー取得：認証チェック済み ctx から userID 抽出  
+	// ------------------------------
+    userID, ok := auth.GetUserID(ctx)
+    if !ok {
+        RespondJSON(ctx, w, &ErrResponse{Message: "unauthorized"}, http.StatusUnauthorized)
+        return
+    }
 
 	now := time.Now()
     t := &entity.TaskTag{

--- a/handler/add_tag_to_task_test.go
+++ b/handler/add_tag_to_task_test.go
@@ -7,6 +7,7 @@ import (
     "net/http/httptest"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-webapi-team/task-app/auth"
 	"github.com/go-webapi-team/task-app/entity"
 	"github.com/go-webapi-team/task-app/store"
 )
@@ -25,6 +26,7 @@ func TestAddTagToTask_Ok(t *testing.T) {
 	rctx.URLParams.Add("task_id", "1")
 	rctx.URLParams.Add("tag_id", "2")
 	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+	r = r.WithContext(auth.WithUserID(r.Context(), 1))
 
 	sut := AddTagToTask{Repo: &fakeTagAdder{}, DB: nil}
 	sut.ServeHTTP(w, r)

--- a/handler/add_task.go
+++ b/handler/add_task.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/go-webapi-team/task-app/auth"
 	"github.com/go-webapi-team/task-app/entity"
 	"github.com/go-webapi-team/task-app/store"
 	"github.com/go-playground/validator/v10"
@@ -54,9 +55,18 @@ func (at *AddTask) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// ------------------------------
+	// 認証ユーザー取得：認証チェック済み ctx から userID 抽出  
+	// ------------------------------
+    userID, ok := auth.GetUserID(ctx)
+    if !ok {
+        RespondJSON(ctx, w, &ErrResponse{Message: "unauthorized"}, http.StatusUnauthorized)
+        return
+    }
+
 	t := &entity.Task{
 		// TODO: 認証機能実装後にログインユーザーの ID を ctx から取得する
-		UserID:      1, 
+		UserID:      userID, 
 		Title:       in.Title,
 		Description: in.Description,
 		Deadline:    in.Deadline,

--- a/handler/add_task_test.go
+++ b/handler/add_task_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-playground/validator/v10"
+	"github.com/go-webapi-team/task-app/auth"
 	"github.com/go-webapi-team/task-app/entity"
 	"github.com/go-webapi-team/task-app/store"
 	"github.com/go-webapi-team/task-app/testutil"
@@ -55,6 +56,7 @@ func TestAddTask(t *testing.T) {
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest(http.MethodPost, "/tasks",
 				bytes.NewReader(testutil.LoadFile(t, tt.reqFile)))
+			r = r.WithContext(auth.WithUserID(r.Context(), 1))
 
 			sut := AddTask{
 				Repo:      &fakeAdder{},

--- a/handler/complete_task_test.go
+++ b/handler/complete_task_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-webapi-team/task-app/auth"
 	"github.com/go-webapi-team/task-app/entity"
 	"github.com/go-webapi-team/task-app/store"
 )
@@ -24,6 +25,7 @@ func TestToggleCompleteTask_Ok(t *testing.T) {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", "1")
 	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+	r = r.WithContext(auth.WithUserID(r.Context(), 1))
 
 	sut := ToggleCompleteTask{Repo: &fakeTaskCompleter{}, DB: nil}
 	sut.ServeHTTP(w, r)

--- a/handler/delete_tag.go
+++ b/handler/delete_tag.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-webapi-team/task-app/auth"
 	"github.com/go-webapi-team/task-app/entity"
 	"github.com/go-webapi-team/task-app/store"
 )
@@ -37,7 +38,14 @@ func (dt *DeleteTag) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID := int64(1) // TODO 認証後に取得
+	// ------------------------------
+	// 認証ユーザー取得：認証チェック済み ctx から userID 抽出 
+	// ------------------------------
+    userID, ok := auth.GetUserID(ctx)
+    if !ok {
+        RespondJSON(ctx, w, &ErrResponse{Message: "unauthorized"}, http.StatusUnauthorized)
+        return
+    }
 
 	if err := dt.Repo.DeleteTag(ctx, dt.DB, userID, entity.TagID(idInt)); err != nil {
 		RespondJSON(ctx, w, &ErrResponse{Message: err.Error()}, http.StatusInternalServerError)

--- a/handler/delete_tag_from_task.go
+++ b/handler/delete_tag_from_task.go
@@ -7,6 +7,7 @@ import (
     "strconv"
 
     "github.com/go-chi/chi/v5"
+    "github.com/go-webapi-team/task-app/auth"
     "github.com/go-webapi-team/task-app/entity"
     "github.com/go-webapi-team/task-app/store"
 )
@@ -46,7 +47,14 @@ func (dt *DeleteTagFromTask) ServeHTTP(w http.ResponseWriter, r *http.Request) {
         return
     }
 
-	userID := int64(1) // TODO 認証実装後に取得
+    // ------------------------------
+	// 認証ユーザー取得：認証チェック済み ctx から userID 抽出 
+	// ------------------------------
+    userID, ok := auth.GetUserID(ctx)
+    if !ok {
+        RespondJSON(ctx, w, &ErrResponse{Message: "unauthorized"}, http.StatusUnauthorized)
+        return
+    }
 
     t := &entity.TaskTag{
         TaskID: entity.TaskID(taskInt),

--- a/handler/delete_tag_from_task_test.go
+++ b/handler/delete_tag_from_task_test.go
@@ -7,6 +7,7 @@ import (
     "testing"
 
     "github.com/go-chi/chi/v5"
+    "github.com/go-webapi-team/task-app/auth"
     "github.com/go-webapi-team/task-app/entity"
     "github.com/go-webapi-team/task-app/store"
 )
@@ -25,6 +26,7 @@ func TestDeleteTagFromTask_Ok(t *testing.T) {
     rctx.URLParams.Add("task_id", "1")
     rctx.URLParams.Add("tag_id", "2")
     r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+    r = r.WithContext(auth.WithUserID(r.Context(), 1))
 
     sut := DeleteTagFromTask{Repo: &fakeTagRemover{}, DB: nil}
     sut.ServeHTTP(w, r)

--- a/handler/delete_tag_test.go
+++ b/handler/delete_tag_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-webapi-team/task-app/auth"
 	"github.com/go-webapi-team/task-app/entity"
 	"github.com/go-webapi-team/task-app/store"
 )
@@ -26,6 +27,7 @@ func TestDeleteTag_OK(t *testing.T) {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", "5")
 	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+	r = r.WithContext(auth.WithUserID(r.Context(), 1))
 
 	sut := DeleteTag{Repo: &fakeTagDeleter{}, DB: nil}
 	sut.ServeHTTP(w, r)

--- a/handler/delete_task.go
+++ b/handler/delete_task.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-webapi-team/task-app/auth"
 	"github.com/go-webapi-team/task-app/entity"
 	"github.com/go-webapi-team/task-app/store"
 )
@@ -36,8 +37,17 @@ func (dt *DeleteTask) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		RespondJSON(ctx, w, &ErrResponse{Message: "Invalid task ID format"}, http.StatusBadRequest)
 		return
 	}
-	// TODO: 認証機能実装後にログインユーザーの ID を ctx から取得する
-	if err := dt.Repo.DeleteTask(ctx, dt.DB, 1, entity.TaskID(idInt)); err != nil {
+
+	// ------------------------------
+	// 認証ユーザー取得：認証チェック済み ctx から userID 抽出 
+	// ------------------------------
+    userID, ok := auth.GetUserID(ctx)
+    if !ok {
+        RespondJSON(ctx, w, &ErrResponse{Message: "unauthorized"}, http.StatusUnauthorized)
+        return
+    }
+	
+	if err := dt.Repo.DeleteTask(ctx, dt.DB, userID, entity.TaskID(idInt)); err != nil {
 		RespondJSON(ctx, w, &ErrResponse{Message: err.Error()}, http.StatusInternalServerError)
 		return
 	}

--- a/handler/delete_task_test.go
+++ b/handler/delete_task_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-webapi-team/task-app/auth"
 	"github.com/go-webapi-team/task-app/entity"
 	"github.com/go-webapi-team/task-app/store"
 )
@@ -24,6 +25,7 @@ func TestDeleteTask_Ok(t *testing.T) {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", "1")
 	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+	r = r.WithContext(auth.WithUserID(r.Context(), 1))
 
 	sut := DeleteTask{Repo: &fakeTaskDeleter{}, DB: nil}
 	sut.ServeHTTP(w, r)

--- a/handler/get_tag_test.go
+++ b/handler/get_tag_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-webapi-team/task-app/auth"
 	"github.com/go-webapi-team/task-app/entity"
 	"github.com/go-webapi-team/task-app/store"
 	"github.com/go-webapi-team/task-app/testutil"
@@ -29,6 +30,7 @@ func TestGetTask(t *testing.T) {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", "1")
 	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+	r = r.WithContext(auth.WithUserID(r.Context(), 1))
 
 	sut := GetTask{Repo: &fakeTaskGetter{t: task}, DB: nil}
 	sut.ServeHTTP(w, r)

--- a/handler/get_task.go
+++ b/handler/get_task.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-webapi-team/task-app/auth"
 	"github.com/go-webapi-team/task-app/entity"
 	"github.com/go-webapi-team/task-app/store"
 )
@@ -36,8 +37,17 @@ func (gt *GetTask) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		RespondJSON(ctx, w, &ErrResponse{Message: "invalid id"}, http.StatusBadRequest)
 		return
 	}
-	// TODO: 認証機能実装後にログインユーザーの ID を ctx から取得する
-	t, err := gt.Repo.GetTask(ctx, gt.DB, 1, entity.TaskID(idInt))
+	
+	// ------------------------------
+	// 認証ユーザー取得：認証チェック済み ctx から userID 抽出 
+	// ------------------------------
+    userID, ok := auth.GetUserID(ctx)
+    if !ok {
+        RespondJSON(ctx, w, &ErrResponse{Message: "unauthorized"}, http.StatusUnauthorized)
+        return
+    }
+
+	t, err := gt.Repo.GetTask(ctx, gt.DB, userID, entity.TaskID(idInt))
 	if err != nil {
 		RespondJSON(ctx, w, &ErrResponse{Message: err.Error()}, http.StatusNotFound)
 		return

--- a/handler/list_tag_test.go
+++ b/handler/list_tag_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-webapi-team/task-app/auth"
 	"github.com/go-webapi-team/task-app/entity"
 	"github.com/go-webapi-team/task-app/store"
 	"github.com/go-webapi-team/task-app/testutil"
@@ -13,7 +14,7 @@ import (
 
 type fakeLister struct{ ret entity.Tags }
 
-func (f *fakeLister) ListTags(_ context.Context, _ store.Queryer) (entity.Tags, error) {
+func (f *fakeLister) ListTags(_ context.Context, _ store.Queryer, _ int64) (entity.Tags, error) {
 	return f.ret, nil
 }
 
@@ -63,6 +64,7 @@ func TestListTag(t *testing.T) {
 				"/tags",
 				nil,
 			)
+			r = r.WithContext(auth.WithUserID(r.Context(), 1))
 
 			// テスト対象となるハンドラ(ListTag)の用意
 			sut := ListTag{

--- a/handler/list_task.go
+++ b/handler/list_task.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/go-webapi-team/task-app/auth"
 	"github.com/go-webapi-team/task-app/entity"
 	"github.com/go-webapi-team/task-app/store"
 )
@@ -77,8 +78,16 @@ func (lt *ListTask) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// TODO: 認証機能実装後にログインユーザーの ID を ctx から取得する
-	ts, err := lt.Repo.ListTasks(ctx, lt.DB, 1, filter)
+	// ------------------------------
+	// 認証ユーザー取得：認証チェック済み ctx から userID 抽出  
+	// ------------------------------
+    userID, ok := auth.GetUserID(ctx)
+    if !ok {
+        RespondJSON(ctx, w, &ErrResponse{Message: "unauthorized"}, http.StatusUnauthorized)
+        return
+    }
+
+	ts, err := lt.Repo.ListTasks(ctx, lt.DB, userID, filter)
 	if err != nil {
 		RespondJSON(ctx, w, &ErrResponse{Message: err.Error()}, http.StatusInternalServerError)
 		return

--- a/handler/list_task_test.go
+++ b/handler/list_task_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-webapi-team/task-app/auth"
 	"github.com/go-webapi-team/task-app/entity"
 	"github.com/go-webapi-team/task-app/store"
 	"github.com/go-webapi-team/task-app/testutil"
@@ -37,6 +38,7 @@ func TestListTask(t *testing.T) {
 			t.Parallel()
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest(http.MethodGet, "/tasks", nil)
+			r = r.WithContext(auth.WithUserID(r.Context(), 1))
 
 			sut := ListTask{
 				Repo: &fakeTaskLister{ret: tt.tasks},

--- a/handler/login.go
+++ b/handler/login.go
@@ -9,7 +9,7 @@ import (
 func LoginHandler(w http.ResponseWriter, r *http.Request) {
 
 	// ToDo:本来はフォーム値を DB 認証する(後続開発でメール・パスワードを検証 → userID を取得する実装に置換)
-	const dummyUserID int64 = 1
+	const dummyUserID int64 = 2
 
 	// セッション生成
 	sessionID := sessions.NewSession(dummyUserID)

--- a/handler/update_task.go
+++ b/handler/update_task.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-webapi-team/task-app/auth"
 	"github.com/go-webapi-team/task-app/entity"
 	"github.com/go-webapi-team/task-app/store"
 	"github.com/go-playground/validator/v10"
@@ -59,10 +60,18 @@ func (ut *UpdateTask) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// ------------------------------
+	// 認証ユーザー取得：認証チェック済み ctx から userID 抽出  
+	// ------------------------------
+    userID, ok := auth.GetUserID(ctx)
+    if !ok {
+        RespondJSON(ctx, w, &ErrResponse{Message: "unauthorized"}, http.StatusUnauthorized)
+        return
+    }
+
 	t := &entity.Task{
 		ID:          entity.TaskID(idInt),
-		// TODO: 認証機能実装後にログインユーザーの ID を ctx から取得する
-		UserID:      1,
+		UserID:      userID,
 		Title:       in.Title,
 		Description: in.Description,
 		Deadline:    in.Deadline,

--- a/handler/update_task_test.go
+++ b/handler/update_task_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-playground/validator/v10"
+	"github.com/go-webapi-team/task-app/auth"
 	"github.com/go-webapi-team/task-app/entity"
 	"github.com/go-webapi-team/task-app/store"
 )
@@ -27,6 +28,7 @@ func TestUpdateTask_Ok(t *testing.T) {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", "1")
 	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+	r = r.WithContext(auth.WithUserID(r.Context(), 1))
 
 	sut := UpdateTask{Repo: &fakeTaskUpdater{}, DB: nil, Validator: validator.New()}
 	sut.ServeHTTP(w, r)

--- a/store/tag.go
+++ b/store/tag.go
@@ -25,10 +25,10 @@ func (r *Repository) CreateTag(ctx context.Context, db Execer, t *entity.Tag) er
 	return nil
 }
 
-func (r *Repository) ListTags(ctx context.Context, db Queryer) (entity.Tags, error) {
-	const sqlStr = `SELECT id, user_id, name, created_at, updated_at FROM tags`
+func (r *Repository) ListTags(ctx context.Context, db Queryer, userID int64) (entity.Tags, error) {
+	const sqlStr = `SELECT id, user_id, name, created_at, updated_at FROM tags WHERE user_id = ?`
 
-	rows, err := db.QueryContext(ctx, sqlStr)
+	rows, err := db.QueryContext(ctx, sqlStr, userID)
 	if err != nil {
 		return nil, err
 	}

--- a/store/tag_test.go
+++ b/store/tag_test.go
@@ -34,11 +34,13 @@ func TestTagRepository_ListTags(t *testing.T) {
 		AddRow(want[0].ID, want[0].UserID, want[0].Name, want[0].CreatedAt, want[0].UpdatedAt).
 		AddRow(want[1].ID, want[1].UserID, want[1].Name, want[1].CreatedAt, want[1].UpdatedAt)
 
-	mock.ExpectQuery(`SELECT id, user_id, name, created_at, updated_at FROM tags`).
+	mock.ExpectQuery(`SELECT id, user_id, name, created_at, updated_at FROM tags WHERE user_id = \?`).
+		WithArgs(int64(1)).
 		WillReturnRows(rows)
 
 	sut := &Repository{Clocker: c}
-	got, err := sut.ListTags(ctx, db)
+	got, err := sut.ListTags(ctx, db, 1)
+
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
ハンドラーとデータアクセス層で、UserIDをハードコーディングしていたのを、認証機能組み込みに合わせて認証チェック済みctxからユーザー取得する対応に修正しました。
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```markdown
## リリースノート

### New Feature
- 認証機能の統合: ハンドラーでユーザーIDを認証済みコンテキストから取得するように変更し、認証失敗時にはHTTPステータス401を返すようにしました。

### Refactor
- `ListTags`関数が`userID`パラメータを受け取るように変更され、SQLクエリがユーザーIDでフィルタリングされるようになりました。

### Test
- テストセットアップにユーザー認証コンテキストを追加し、新しい認証メカニズムと整合性を持たせました。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->